### PR TITLE
objdump: use -arch-name instead of -triple

### DIFF
--- a/src/bin/cargo-objdump.rs
+++ b/src/bin/cargo-objdump.rs
@@ -5,7 +5,7 @@ use std::process;
 fn main() {
     match cbu::run(
         true,
-        |ctxt| ctxt.objdump(ctxt.tool_args().iter().all(|s| !s.ends_with(".wasm"))),
+        |ctxt| ctxt.objdump(),
         |_ctxt, stdout| stdout.into(),
     ) {
         Err(e) => eprintln!("error: {}", e),

--- a/src/llvm.rs
+++ b/src/llvm.rs
@@ -1,0 +1,88 @@
+use {rustc, Endian};
+
+// Here we map Rust arches to LLVM arches
+//
+// Rust knows these arches as of 1.28 (from librustc_target/abi/call/mod.rs)
+//
+// - aarch64
+// - arm
+// - asmjs (emscripten fork only)
+// - hexagon
+// - mips
+// - mips64
+// - msp430
+// - nvptx
+// - nvptx64
+// - powerpc
+// - riscv32
+// - riscv64
+// - s390x
+// - sparc
+// - sparc64
+// - wasm32
+// - x86
+// - x86_64
+//
+// Rust LLVM knows these arches of 7.0 (from `llvm-objdump -version`)
+//
+// - aarch64
+// - aarch64_be
+// - arm
+// - arm64
+// - armeb
+// - hexagon
+// - mips
+// - mips64
+// - mips64el
+// - mipsel
+// - msp430
+// - nvptx
+// - nvptx64
+// - ppc32
+// - ppc64
+// - ppc64le
+// - riscv32
+// - riscv64
+// - sparc
+// - sparcel
+// - sparcv9
+// - systemz
+// - thumb
+// - thumbeb
+// - wasm32
+// - wasm64
+// - x86
+// - x86-64
+pub fn arch_name<'a>(cfg: &'a rustc::Cfg, target: &'a str) -> &'a str {
+    let endian = cfg.endian();
+    let arch = cfg.arch();
+
+    if target.starts_with("thumb") {
+        // no way to tell from `--print cfg` that the target is thumb only so we
+        // completely rely on the target name here
+        match endian {
+            Endian::Little => "thumb",
+            Endian::Big => "thumbeb",
+        }
+    } else {
+        match (arch, endian) {
+            // non standard endianness
+            ("aarch64", Endian::Big) => "aarch64_be",
+            ("arm", Endian::Big) => "armeb",
+            ("mips", Endian::Little) => "mipsel",
+            ("mips64", Endian::Little) => "mips64el",
+            ("powerpc64", Endian::Little) => "ppc64le",
+            ("sparc", Endian::Little) => "sparcel",
+
+            // names that match
+            ("powerpc", _) => "ppc",
+            ("powerpc64", Endian::Big) => "ppc64",
+            ("sparc64", _) => "sparcv9",
+            ("s390x", _) => "systemz",
+            ("x86_64", _) => "x86-64",
+
+            // all the other names match as of 1.28
+            _ => arch,
+        }
+    }
+}

--- a/src/rustc.rs
+++ b/src/rustc.rs
@@ -1,0 +1,71 @@
+use std::process::Command;
+
+use failure;
+
+use {Endian, Result};
+
+/// Parsed `rustc --print cfg`
+pub struct Cfg {
+    arch: String,
+    endian: Endian,
+}
+
+impl Cfg {
+    pub fn arch(&self) -> &str {
+        &self.arch
+    }
+
+    pub fn endian(&self) -> Endian {
+        self.endian
+    }
+}
+
+impl Cfg {
+    pub fn parse(target: &str) -> Result<Self> {
+        const MSG: &str = "parsing `rustc --print cfg`";
+
+        let mut rustc = Command::new("rustc");
+        rustc.args(&["--target", target]);
+
+        let stdout = String::from_utf8(rustc.arg("--print").arg("cfg").output()?.stdout)?;
+
+        let mut arch = None;
+        let mut endian = None;
+        for line in stdout.lines() {
+            if line.starts_with("target_arch") {
+                arch = Some(
+                    line.split('"')
+                        .nth(1)
+                        .map(|s| s.to_owned())
+                        .ok_or_else(|| failure::err_msg(MSG))?,
+                );
+            } else if line.starts_with("target_endian") {
+                endian = Some(if line.ends_with("\"little\"") {
+                    Endian::Little
+                } else {
+                    Endian::Big
+                });
+            }
+        }
+
+        if let (Some(arch), Some(endian)) = (arch, endian) {
+            Ok(Cfg { arch, endian })
+        } else {
+            Err(failure::err_msg(MSG))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Cfg;
+    use Endian;
+
+    #[test]
+    fn x86_64() {
+        let cfg = Cfg::parse("x86_64-unknown-linux-gnu").unwrap();
+
+        assert_eq!(cfg.arch, "x86_64");
+        assert_eq!(cfg.endian, Endian::Little);
+    }
+}


### PR DESCRIPTION
infer the arch-name from the output of `rustc --print cfg` is more robust than
just using the target name for the -triple flag.

fixes #17

r? @rust-embedded/tools (anyone)
cc @danc86