### PR TITLE
add rust-* tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,27 +22,43 @@ $ rustup component add llvm-tools-preview
 
 ## Usage
 
-This
+This:
 
 ``` console
-$ cargo $tool -- ${args[@]}
+$ rust-$tool ${args[@]}
 ```
 
-is basically sugar for
+is basically sugar for:
 
 ``` console
 $ $(find $(rustc --print sysroot) -name llvm-$tool) ${args[@]}
+```
+
+Apart from these `rust-*` tools, which are direct proxies for the llvm tools in
+the `llvm-tools-preview` component, the crate also provides some Cargo
+subcommands that will first build the project and then run the llvm tool on the
+output artifact. This:
+
+``` console
+$ cargo size --example foo
+```
+
+is sugar for:
+
+``` console
+$ cargo build --example foo
+$ rust-size target/examples/foo
 ```
 
 In the case of `cargo-objdump` the architecture of the compilation target is
 passed as `-arch-name=$target` to `llvm-objdump`. `-arch-name` specifies to
 which architecture disassemble the object file to.
 
-You can get more information about the CLI of each tool by running `cargo $tool
--- --help`.
+You can get more information about the CLI of each tool by running `rust-$tool
+ -help`.
 
-All the subcommands accept a `--verbose` / `-v` flag. In verbose mode the
-`llvm-$tool` invocation will be printed to stderr.
+All the Cargo subcommands accept a `--verbose` / `-v` flag. In verbose mode the
+`rust-$tool` invocation will be printed to stderr.
 
 Build and inspect mode: Some subcommands accept the flags: `--bin`, `--example`,
 `--lib`, `--target` and `--release`. These can be used to make the subcommand

--- a/src/bin/rust-ar.rs
+++ b/src/bin/rust-ar.rs
@@ -1,0 +1,10 @@
+extern crate cargo_binutils as cbu;
+
+use std::process;
+
+fn main() {
+    match cbu::forward("llvm-ar") {
+        Err(e) => eprintln!("error: {}", e),
+        Ok(ec) => process::exit(ec),
+    }
+}

--- a/src/bin/rust-ld.rs
+++ b/src/bin/rust-ld.rs
@@ -1,0 +1,10 @@
+extern crate cargo_binutils as cbu;
+
+use std::process;
+
+fn main() {
+    match cbu::forward("rust-lld") {
+        Err(e) => eprintln!("error: {}", e),
+        Ok(ec) => process::exit(ec),
+    }
+}

--- a/src/bin/rust-nm.rs
+++ b/src/bin/rust-nm.rs
@@ -1,0 +1,10 @@
+extern crate cargo_binutils as cbu;
+
+use std::process;
+
+fn main() {
+    match cbu::forward("llvm-nm") {
+        Err(e) => eprintln!("error: {}", e),
+        Ok(ec) => process::exit(ec),
+    }
+}

--- a/src/bin/rust-objcopy.rs
+++ b/src/bin/rust-objcopy.rs
@@ -1,0 +1,10 @@
+extern crate cargo_binutils as cbu;
+
+use std::process;
+
+fn main() {
+    match cbu::forward("llvm-objcopy") {
+        Err(e) => eprintln!("error: {}", e),
+        Ok(ec) => process::exit(ec),
+    }
+}

--- a/src/bin/rust-objdump.rs
+++ b/src/bin/rust-objdump.rs
@@ -1,0 +1,10 @@
+extern crate cargo_binutils as cbu;
+
+use std::process;
+
+fn main() {
+    match cbu::forward("llvm-objdump") {
+        Err(e) => eprintln!("error: {}", e),
+        Ok(ec) => process::exit(ec),
+    }
+}

--- a/src/bin/rust-profdata.rs
+++ b/src/bin/rust-profdata.rs
@@ -1,0 +1,10 @@
+extern crate cargo_binutils as cbu;
+
+use std::process;
+
+fn main() {
+    match cbu::forward("llvm-profdata") {
+        Err(e) => eprintln!("error: {}", e),
+        Ok(ec) => process::exit(ec),
+    }
+}

--- a/src/bin/rust-readobj.rs
+++ b/src/bin/rust-readobj.rs
@@ -1,0 +1,10 @@
+extern crate cargo_binutils as cbu;
+
+use std::process;
+
+fn main() {
+    match cbu::forward("llvm-readobj") {
+        Err(e) => eprintln!("error: {}", e),
+        Ok(ec) => process::exit(ec),
+    }
+}

--- a/src/bin/rust-size.rs
+++ b/src/bin/rust-size.rs
@@ -1,0 +1,10 @@
+extern crate cargo_binutils as cbu;
+
+use std::process;
+
+fn main() {
+    match cbu::forward("llvm-size") {
+        Err(e) => eprintln!("error: {}", e),
+        Ok(ec) => process::exit(ec),
+    }
+}

--- a/src/bin/rust-strip.rs
+++ b/src/bin/rust-strip.rs
@@ -1,0 +1,10 @@
+extern crate cargo_binutils as cbu;
+
+use std::process;
+
+fn main() {
+    match cbu::forward("llvm-strip") {
+        Err(e) => eprintln!("error: {}", e),
+        Ok(ec) => process::exit(ec),
+    }
+}


### PR DESCRIPTION
these are direct aliases for the llvm tools: rust-size == llvm-size (remember
that `llvm-size` is not in PATH)

this commit also shrinks the verbose output of the Cargo subcommands

``` console
$ cargo size --bin hello -v
"cargo" "build" "--bin" "hello"
   Compiling hello v0.1.0 (/tmp/hello)
    Finished dev [unoptimized + debuginfo] target(s) in 0.25s
"rust-size" "hello"
   text    data     bss     dec     hex filename
 195795    8120     544  204459   31eab hello
```

closes #43 (this commit adds rust-ar)