### PR TITLE
Add rust-lld.

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,17 @@ $ stat --printf="%s\n" smaller-hello
 424432
 ```
 
+### `rust-lld`
+
+Provides a link to `lld`.
+Used to change the linker or providing a workaround if `-C linker-flavor` is not doing the job.
+
+`.cargo/config`
+```toml
+[target.wasm32-unknown-unknown]
+linker = "rust-lld"
+```
+
 ## License
 
 Licensed under either of

--- a/src/bin/rust-lld.rs
+++ b/src/bin/rust-lld.rs
@@ -1,0 +1,10 @@
+extern crate cargo_binutils as cbu;
+
+use std::process;
+
+fn main() {
+    match cbu::forward("rust-lld") {
+        Err(e) => eprintln!("error: {}", e),
+        Ok(ec) => process::exit(ec),
+    }
+}


### PR DESCRIPTION
Adds a link to `rust-lld`, I'm using it frequently in combination with `-Z build-std` and using the `rust-lld` instead of the msvc `link` on windows.

Fixes #47.