### PR TITLE
Fix travis windows build

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -5,6 +5,9 @@ main() {
         rustup component add llvm-tools-preview
     fi
 
+    if [ $T = x86_64-pc-windows-msvc ]; then
+        rustup target add $T
+    fi
     if [ $T = x86_64-unknown-linux-musl ]; then
         rustup target add $T
         curl -L https://github.com/japaric/musl-bin/raw/master/14.04.tar.gz | tar xz -C $HOME


### PR DESCRIPTION
The windows CI build is currently broken due to travis defaulting to GNU toolchain for windows builds.