### PR TITLE
Argument Cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Added `--quiet` and `--color` arguments to be passed to `cargo build`
+- Added `--test` and `--bench` build arguments to allow targeting testing artifacts
+
 ### Fixed
 
 - Fixed handling of `--lib` argument to reflect how its used with `cargo build`
+- Fixed `--` argument handling to ensure argument validation
+
+### Changed
+
+- Changed help output to more closely reflect the help command of `cargo` subcommands
 
 ## [v0.2.0] - 2020-04-11
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,6 +228,15 @@ fn determine_artifact(matches: &clap::ArgMatches) -> Result<Option<Artifact>, fa
     let mut cargo = Command::new("cargo");
     cargo.arg("build");
 
+    if matches.is_present("quiet") {
+        cargo.arg("--quiet");
+    }
+
+    if let Some(color) = matches.value_of("color") {
+        cargo.arg("--color");
+        cargo.arg(color);
+    }
+
     // NOTE we do *not* use `project.target()` here because Cargo will figure things out on
     // its own (i.e. it will search and parse .cargo/config, etc.)
     if let Some(target) = target_flag {
@@ -338,6 +347,12 @@ To see all the flags the proxied tool accepts run `cargo-{} -- -help`.{}",
         // we ignore this argument
         .arg(Arg::with_name("binary-name").hidden(true))
         .arg(
+            Arg::with_name("quiet")
+                .long("quiet")
+                .short("q")
+                .help("Don't print build output from `cargo build`"),
+        )
+        .arg(
             Arg::with_name("target")
                 .long("target")
                 .takes_value(true)
@@ -349,6 +364,13 @@ To see all the flags the proxied tool accepts run `cargo-{} -- -help`.{}",
                 .long("verbose")
                 .short("v")
                 .help("Use verbose output"),
+        )
+        .arg(
+            Arg::with_name("color")
+                .long("color")
+                .takes_value(true)
+                .possible_values(&["auto", "always", "never"])
+                .help("Coloring: auto, always, never"),
         )
         .arg(
             Arg::with_name("args")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,9 +314,6 @@ fn determine_artifact(matches: &clap::ArgMatches) -> Result<Option<Artifact>, fa
 
 pub fn run(tool: Tool, examples: Option<&str>) -> Result<i32, failure::Error> {
     let name = tool.name();
-    let needs_build = tool.needs_build();
-
-    let app = App::new(format!("cargo-{}", name));
     let about = format!(
         "Proxy for the `llvm-{}` tool shipped with the Rust toolchain.",
         name
@@ -329,7 +326,7 @@ To see all the flags the proxied tool accepts run `cargo-{} -- -help`.{}",
         name,
         examples.unwrap_or("")
     );
-    let app = app
+    let app = App::new(format!("cargo-{}", name))
         .about(&*about)
         .version(env!("CARGO_PKG_VERSION"))
         .setting(AppSettings::TrailingVarArg)
@@ -358,7 +355,7 @@ To see all the flags the proxied tool accepts run `cargo-{} -- -help`.{}",
         )
         .after_help(&*after_help);
 
-    let matches = if needs_build {
+    let app = if tool.needs_build() {
         app.arg(
             Arg::with_name("bin")
                 .long("bin")
@@ -398,9 +395,9 @@ To see all the flags the proxied tool accepts run `cargo-{} -- -help`.{}",
         )
     } else {
         app
-    }
-    .get_matches();
+    };
 
+    let matches = app.get_matches();
     let verbose = matches.is_present("verbose");
     let target_flag = matches.value_of("target");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,8 +350,12 @@ To see all the flags the proxied tool accepts run `cargo-{} -- -help`.{}",
                 .short("v")
                 .help("Use verbose output"),
         )
-        .arg(Arg::with_name("--").short("-").hidden_short_help(true))
-        .arg(Arg::with_name("args").multiple(true))
+        .arg(
+            Arg::with_name("args")
+                .last(true)
+                .multiple(true)
+                .help("The arguments to be proxied to the tool"),
+        )
         .after_help(&*after_help);
 
     let matches = if needs_build {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -442,10 +442,6 @@ To see all the flags the proxied tool accepts run `cargo-{} -- -help`.{}",
     let artifact = determine_artifact(&matches)?;
 
     let mut tool_args = vec![];
-    if let Some(arg) = matches.value_of("--") {
-        tool_args.push(arg);
-    }
-
     if let Some(args) = matches.values_of("args") {
         tool_args.extend(args);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,8 +329,11 @@ To see all the flags the proxied tool accepts run `cargo-{} -- -help`.{}",
     let app = App::new(format!("cargo-{}", name))
         .about(&*about)
         .version(env!("CARGO_PKG_VERSION"))
-        .setting(AppSettings::TrailingVarArg)
-        .setting(AppSettings::DontCollapseArgsInUsage)
+        .settings(&[
+            AppSettings::UnifiedHelpMessage,
+            AppSettings::DeriveDisplayOrder,
+            AppSettings::DontCollapseArgsInUsage,
+        ])
         // as this is used as a Cargo subcommand the first argument will be the name of the binary
         // we ignore this argument
         .arg(Arg::with_name("binary-name").hidden(true))


### PR DESCRIPTION
## Changes
- Changed `--` handling to use [`Arg.last(bool)`](https://docs.rs/clap/2.33.0/clap/struct.Arg.html#method.last)
- Changed AppSettings to reflect how cargo handles args ([cargo cli](https://github.com/rust-lang/cargo/blob/dcddf15203b91b1769060e38921974cddce4c408/src/bin/cargo/cli.rs#L257-L262), [cargo subcommands](https://github.com/rust-lang/cargo/blob/7d720ef0515b252ca566c088e96726a400400b04/src/cargo/util/command_prelude.rs#L251-L255))
- Added support for `--quiet` and `--color` to be passed to `cargo build`
- Reworked build arguments
  - Use clap for argument requirement by using [`Arg.conflicts_with_all(...)`](https://docs.rs/clap/2.33.0/clap/struct.Arg.html#method.conflicts_with_all)
  - Use `if let Some(...)` to avoid using `.is_present` then `.value_of(...).unwrap()`
- Added support for `--test` and `--bench` targets

**Example `--help` output:**
<details>
<summary>Before</summary><p>

```
$ cargo size --help
cargo-size 0.2.0
Proxy for the `llvm-size` tool shipped with the Rust toolchain.

USAGE:
    cargo-size.exe [FLAGS] [OPTIONS] [--] [args]...

FLAGS:
        --all-features
            Activate all available features

    -h, --help
            Prints help information

        --lib
            Build only this package's library

        --release
            Build artifacts in release mode, with optimizations

    -V, --version
            Prints version information

    -v, --verbose
            Use verbose output


OPTIONS:
        --bin <NAME>
            Build only the specified binary

        --example <NAME>
            Build only the specified example

        --features <FEATURES>
            Space-separated list of features to activate

        --target <TRIPLE>
            Target triple for which the code is compiled


ARGS:
    <-->


    <args>...



The arguments specified *after* the `--` will be passed to the proxied tool invocation.

To see all the flags the proxied tool accepts run `cargo-size -- -help`.

EXAMPLES

`cargo size --bin foo --release`        - prints binary size in Berkeley format
`cargo size --bin foo --release -- -A`  - prints binary size in System V format
```
</p></details>

<details>
<summary>After</summary><p>

```
$ cargo size --help
cargo-size 0.2.0
Proxy for the `llvm-size` tool shipped with the Rust toolchain.

USAGE:
    cargo-size.exe [OPTIONS] --bench <NAME> --bin <NAME> --example <NAME> --lib --test <NAME> [-- <args>...]

OPTIONS:
    -q, --quiet                  Don't print build output from `cargo build`
        --target <TRIPLE>        Target triple for which the code is compiled
    -v, --verbose                Use verbose output
        --color <color>          Coloring: auto, always, never [possible values: auto, always, never]
        --lib                    Build only this package's library
        --bin <NAME>             Build only the specified binary
        --example <NAME>         Build only the specified example
        --test <NAME>            Build only the specified test target
        --bench <NAME>           Build only the specified bench target
        --release                Build artifacts in release mode, with optimizations
        --features <FEATURES>    Space-separated list of features to activate
        --all-features           Activate all available features
    -h, --help                   Prints help information
    -V, --version                Prints version information

ARGS:
    <args>...    The arguments to be proxied to the tool

The arguments specified *after* the `--` will be passed to the proxied tool invocation.

To see all the flags the proxied tool accepts run `cargo-size -- -help`.

EXAMPLES

`cargo size --bin foo --release`        - prints binary size in Berkeley format
`cargo size --bin foo --release -- -A`  - prints binary size in System V format
```
</p></details>

---

<details>
<summary>cargo build --help</summary><p>

```
$ cargo build --help
cargo.exe-build
Compile a local package and all of its dependencies

USAGE:
    cargo.exe build [OPTIONS]

OPTIONS:
    -q, --quiet                      No output printed to stdout
    -p, --package <SPEC>...          Package to build (see `cargo help pkgid`)
        --all                        Alias for --workspace (deprecated)
        --workspace                  Build all packages in the workspace
        --exclude <SPEC>...          Exclude packages from the build
    -j, --jobs <N>                   Number of parallel jobs, defaults to # of CPUs
        --lib                        Build only this package's library
        --bin <NAME>...              Build only the specified binary
        --bins                       Build all binaries
        --example <NAME>...          Build only the specified example
        --examples                   Build all examples
        --test <NAME>...             Build only the specified test target
        --tests                      Build all tests
        --bench <NAME>...            Build only the specified bench target
        --benches                    Build all benches
        --all-targets                Build all targets
        --release                    Build artifacts in release mode, with optimizations
        --profile <PROFILE-NAME>     Build artifacts with the specified profile
        --features <FEATURES>...     Space-separated list of features to activate
        --all-features               Activate all available features
        --no-default-features        Do not activate the `default` feature
        --target <TRIPLE>            Build for the target triple
        --target-dir <DIRECTORY>     Directory for all generated artifacts
        --out-dir <PATH>             Copy final artifacts to this directory (unstable)
        --manifest-path <PATH>       Path to Cargo.toml
        --message-format <FMT>...    Error format
        --build-plan                 Output the build plan in JSON (unstable)
    -v, --verbose                    Use verbose output (-vv very verbose/build.rs output)
        --color <WHEN>               Coloring: auto, always, never
        --frozen                     Require Cargo.lock and cache are up to date
        --locked                     Require Cargo.lock is up to date
        --offline                    Run without accessing the network
    -Z <FLAG>...                     Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
    -h, --help                       Prints help information

All packages in the workspace are built if the `--workspace` flag is supplied. The
`--workspace` flag is automatically assumed for a virtual manifest.
Note that `--exclude` has to be specified in conjunction with the `--workspace` flag.

Compilation can be configured via the use of profiles which are configured in
the manifest. The default profile for this command is `dev`, but passing
the --release flag will use the `release` profile instead.
```
</p></details>