### PR TITLE
Fix artifact matching for all lib kinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed handling of `--lib` argument to reflect how its used with `cargo build`
 - Fixed `--` argument handling to ensure argument validation
+- Fixed `--lib` to be able to support `lib`, `rlib`, `dylib`, `cdylib`, etc.
 
 ### Changed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,12 @@ impl<'a> BuildType<'a> {
             | BuildType::Bench(target_name) => {
                 artifact.target.name == *target_name && artifact.executable.is_some()
             }
-            BuildType::Lib => artifact.target.kind.iter().any(|s| s == "lib"),
+            // For info about 'kind' values see:
+            // https://github.com/rust-lang/cargo/blob/d47a9545db81fe6d7e6c542bc8154f09d0e6c788/src/cargo/core/manifest.rs#L166-L181
+            // Since LibKind can be an arbitrary string `LibKind:Other(String)` we filter by what it can't be
+            BuildType::Lib => artifact.target.kind.iter().any(|s| {
+                s != "bin" && s != "example" && s != "test" && s != "custom-build" && s != "bench"
+            }),
         }
     }
 }


### PR DESCRIPTION
Allows artifact matching to work with lib kinds other than "lib".

Fixes https://github.com/rust-embedded/cargo-binutils/issues/51
I tested with lib, rlib, dylib and proc-macro with `cargo strip` and all appeared to work correctly.
 
Fixes https://github.com/rust-embedded/cargo-binutils/issues/22
Tested using the wasm hello-world from https://wasmbyexample.dev/examples/hello-world/hello-world.rust.en-us.html
Running the following command works perfectly `$ cargo objdump --lib --target wasm32-unknown-unknown -- -d`