### PR TITLE
Add support for --package and allow multiple workspace members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added `--quiet` and `--color` arguments to be passed to `cargo build`
 - Added `--test` and `--bench` build arguments to allow targeting testing artifacts
+- Added `--package` argument so its possible to specify a target package in a workspace
 
 ### Fixed
 


### PR DESCRIPTION
Adds support for the `--package` argument to be able to specify a target workspace member.

Fixes https://github.com/rust-embedded/cargo-binutils/issues/41
Tested by creating a workspace based on the examples on 
https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html

r? @therealprof