### PR TITLE
Simplify cargo bins and reorganize functions in lib.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `--quiet` and `--color` arguments to be passed to `cargo build`
 - Added `--test` and `--bench` build arguments to allow targeting testing artifacts
 - Added `--package` argument so its possible to specify a target package in a workspace
+- Added `--no-default-features` cargo argument support
+- Added `--profile` argument to allow specifying the profile to build the target package with
+- Added `--frozen`, `--locked`, `--offline` cargo argument support
+- Added `-Z` argument to allow use of unstable cargo features
 
 ### Fixed
 
@@ -21,6 +25,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed panic due to broken pipe, caused by `bail!` while `cargo build` is running.
   Additionally fixes broken output format due to interrupted stderr output from `cargo build`
 - Fixed `rust-*` binaries exiting with exit code 0 if the tool was not found
+- Fixed `cargo build` running for `cargo profdata` when its not required
+- Fixed `--features` not allowing multiple
 
 ### Changed
 
@@ -28,6 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Removed `walkdir` dependency by using expected path to tool executable
 - Updated `cargo_metadata 0.9 -> 0.10`
 - Replaced `failure` dependency with [`anyhow`](https://github.com/dtolnay/anyhow)
+- Allowed  multiple levels of verbosity and verbose cargo output via `-vv` and `-vvv`
 
 ## [v0.2.0] - 2020-04-11
 

--- a/src/bin/cargo-nm.rs
+++ b/src/bin/cargo-nm.rs
@@ -1,7 +1,3 @@
-use std::process;
-
-use cargo_binutils::Tool;
-
 const EXAMPLES: &str = "
 
 EXAMPLES
@@ -10,8 +6,5 @@ EXAMPLES
 `cargo nm --lib -- -print-size -size-sort` - lists all symbols sorted by size (smallest first)";
 
 fn main() {
-    match cargo_binutils::run(Tool::Nm, Some(EXAMPLES)) {
-        Err(e) => eprintln!("error: {}", e),
-        Ok(ec) => process::exit(ec),
-    }
+    cargo_binutils::Tool::Nm.cargo_exec(Some(EXAMPLES))
 }

--- a/src/bin/cargo-objcopy.rs
+++ b/src/bin/cargo-objcopy.rs
@@ -1,7 +1,3 @@
-use std::process;
-
-use cargo_binutils::Tool;
-
 const EXAMPLES: &str = "
 
 EXAMPLES
@@ -9,8 +5,5 @@ EXAMPLES
 `cargo objcopy --bin foo -- -O binary foo.hex`  - converts the output (e.g. ELF) into binary format";
 
 fn main() {
-    match cargo_binutils::run(Tool::Objcopy, Some(EXAMPLES)) {
-        Err(e) => eprintln!("error: {}", e),
-        Ok(ec) => process::exit(ec),
-    }
+    cargo_binutils::Tool::Objcopy.cargo_exec(Some(EXAMPLES))
 }

--- a/src/bin/cargo-objdump.rs
+++ b/src/bin/cargo-objdump.rs
@@ -1,7 +1,3 @@
-use std::process;
-
-use cargo_binutils::Tool;
-
 const EXAMPLES: &str = "
 
 EXAMPLES
@@ -10,8 +6,5 @@ EXAMPLES
 `cargo objdump --bin foo --release -- -s -j .rodata`    - prints the contents of the .rodata section";
 
 fn main() {
-    match cargo_binutils::run(Tool::Objdump, Some(EXAMPLES)) {
-        Err(e) => eprintln!("error: {}", e),
-        Ok(ec) => process::exit(ec),
-    }
+    cargo_binutils::Tool::Objdump.cargo_exec(Some(EXAMPLES))
 }

--- a/src/bin/cargo-profdata.rs
+++ b/src/bin/cargo-profdata.rs
@@ -1,10 +1,3 @@
-use std::process;
-
-use cargo_binutils::Tool;
-
 fn main() {
-    match cargo_binutils::run(Tool::Profdata, None) {
-        Err(e) => eprintln!("error: {}", e),
-        Ok(ec) => process::exit(ec),
-    }
+    cargo_binutils::Tool::Profdata.cargo_exec(None)
 }

--- a/src/bin/cargo-readobj.rs
+++ b/src/bin/cargo-readobj.rs
@@ -1,7 +1,3 @@
-use std::process;
-
-use cargo_binutils::Tool;
-
 const EXAMPLES: &str = "
 
 EXAMPLES
@@ -10,8 +6,5 @@ EXAMPLES
 `cargo readobj --bin app -- -t` - Displays the symbol table";
 
 fn main() {
-    match cargo_binutils::run(Tool::Readobj, Some(EXAMPLES)) {
-        Err(e) => eprintln!("error: {}", e),
-        Ok(ec) => process::exit(ec),
-    }
+    cargo_binutils::Tool::Readobj.cargo_exec(Some(EXAMPLES))
 }

--- a/src/bin/cargo-size.rs
+++ b/src/bin/cargo-size.rs
@@ -1,7 +1,3 @@
-use std::process;
-
-use cargo_binutils::Tool;
-
 const EXAMPLES: &str = "
 
 EXAMPLES
@@ -10,8 +6,5 @@ EXAMPLES
 `cargo size --bin foo --release -- -A`  - prints binary size in System V format";
 
 fn main() {
-    match cargo_binutils::run(Tool::Size, Some(EXAMPLES)) {
-        Err(e) => eprintln!("error: {}", e),
-        Ok(ec) => process::exit(ec),
-    }
+    cargo_binutils::Tool::Size.cargo_exec(Some(EXAMPLES))
 }

--- a/src/bin/cargo-strip.rs
+++ b/src/bin/cargo-strip.rs
@@ -1,7 +1,3 @@
-use std::process;
-
-use cargo_binutils::Tool;
-
 const EXAMPLES: &str = "
 
 EXAMPLES
@@ -9,8 +5,5 @@ EXAMPLES
 `cargo strip --bin foo --release -- -strip-all -o stripped`     - strips all symbols";
 
 fn main() {
-    match cargo_binutils::run(Tool::Strip, Some(EXAMPLES)) {
-        Err(e) => eprintln!("error: {}", e),
-        Ok(ec) => process::exit(ec),
-    }
+    cargo_binutils::Tool::Strip.cargo_exec(Some(EXAMPLES))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,11 +3,11 @@
 use std::io::{self, BufReader, Write};
 use std::path::{Component, Path};
 use std::process::{Command, Stdio};
-use std::str;
+use std::{env, str};
 
 use anyhow::{bail, Result};
 use cargo_metadata::{Artifact, CargoOpt, Message, Metadata, MetadataCommand};
-use clap::{App, AppSettings, Arg};
+use clap::{App, AppSettings, Arg, ArgMatches};
 use rustc_cfg::Cfg;
 
 pub use tool::Tool;
@@ -16,20 +16,6 @@ mod llvm;
 mod postprocess;
 mod rustc;
 mod tool;
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum Endian {
-    Little,
-    Big,
-}
-
-/// Execution context
-// TODO this should be some sort of initialize once, read-only singleton
-pub struct Context {
-    cfg: Cfg,
-    /// Final compilation target
-    target: String,
-}
 
 /// Search for `file` in `path` and its parent directories
 fn search<'p>(path: &'p Path, file: &str) -> Option<&'p Path> {
@@ -49,6 +35,14 @@ where
     Ok(de::from_str(&s)?)
 }
 
+/// Execution context
+// TODO this should be some sort of initialize once, read-only singleton
+pub struct Context {
+    cfg: Cfg,
+    /// Final compilation target
+    target: String,
+}
+
 impl Context {
     /* Constructors */
     /// Get a context structure from a built artifact.
@@ -56,9 +50,9 @@ impl Context {
         // Currently there is no clean way to get the target triple from cargo so we can only make
         // an approximation, we do this by extracting the target triple from the artifacts path.
         // For more info on the path structure see: https://doc.rust-lang.org/cargo/guide/build-cache.html
-        // In the future once the feature becomes stable we will be able to use
-        // `cargo build --build-plan` to get the target triple.
-        // See: https://github.com/rust-lang/cargo/issues/5579
+
+        // In the future it may be possible to replace this code and use a cargo feature:
+        // See: https://github.com/rust-lang/cargo/issues/5579, https://github.com/rust-lang/cargo/issues/8002
 
         // Should always succeed.
         let target_path = artifact.filenames[0].strip_prefix(metadata.target_directory)?;
@@ -82,9 +76,7 @@ impl Context {
     /// Get a context structure from a provided target flag, used when cargo
     /// was not used to build the binary.
     fn from_flag(metadata: Metadata, target_flag: Option<&str>) -> Result<Self> {
-        let meta = rustc_version::version_meta()?;
-        let host = meta.host;
-        let host_target_name = host;
+        let host_target_name = rustc_version::version_meta()?.host;
 
         // Get the "default" target override in .cargo/config.
         let mut config_target_name = None;
@@ -113,28 +105,6 @@ impl Context {
             cfg,
             target: target_name.to_string(),
         })
-    }
-
-    fn rustc_cfg(&self) -> &Cfg {
-        &self.cfg
-    }
-
-    fn tool(&self, tool: Tool, target: &str) -> Command {
-        let mut c = Command::new(format!("rust-{}", tool.name()));
-
-        if tool == Tool::Objdump {
-            let arch_name = llvm::arch_name(self.rustc_cfg(), target);
-
-            if arch_name == "thumb" {
-                // `-arch-name=thumb` doesn't produce the right output so instead we pass
-                // `-triple=$target`, which contains more information about the target
-                c.args(&["-triple", target]);
-            } else {
-                c.args(&["-arch-name", arch_name]);
-            }
-        }
-
-        c
     }
 }
 
@@ -167,21 +137,316 @@ impl<'a> BuildType<'a> {
     }
 }
 
-fn determine_artifact(matches: &clap::ArgMatches) -> Result<(Metadata, Option<Artifact>)> {
-    let verbose = matches.is_present("verbose");
-    let target_flag = matches.value_of("target");
+fn args(tool: Tool, examples: Option<&str>) -> ArgMatches {
+    let name = tool.name();
+    let about = format!(
+        "Proxy for the `llvm-{}` tool shipped with the Rust toolchain.",
+        name
+    );
+    let after_help = format!(
+        "\
+The arguments specified *after* the `--` will be passed to the proxied tool invocation.
 
+To see all the flags the proxied tool accepts run `cargo-{} -- -help`.{}",
+        name,
+        examples.unwrap_or("")
+    );
+
+    let app = App::new(format!("cargo-{}", name))
+        .about(&*about)
+        .version(env!("CARGO_PKG_VERSION"))
+        .settings(&[
+            AppSettings::UnifiedHelpMessage,
+            AppSettings::DeriveDisplayOrder,
+            AppSettings::DontCollapseArgsInUsage,
+        ])
+        // as this is used as a Cargo subcommand the first argument will be the name of the binary
+        // we ignore this argument
+        .args(&[
+            Arg::with_name("binary-name").hidden(true),
+            Arg::with_name("verbose")
+                .long("verbose")
+                .short("v")
+                .multiple(true)
+                .help("Use verbose output (-vv cargo verbose or -vvv for build.rs output)"),
+            Arg::with_name("args")
+                .last(true)
+                .multiple(true)
+                .help("The arguments to be proxied to the tool"),
+        ])
+        .after_help(&*after_help);
+
+    if tool.needs_build() {
+        app.args(&[
+            Arg::with_name("quiet")
+                .long("quiet")
+                .short("q")
+                .help("Don't print build output from `cargo build`"),
+            Arg::with_name("package")
+                .long("package")
+                .short("p")
+                .takes_value(true)
+                .value_name("SPEC")
+                .help("Package to build (see `cargo help pkgid`)"),
+            Arg::with_name("jobs")
+                .long("jobs")
+                .short("j")
+                .value_name("N")
+                .help("Number of parallel jobs, defaults to # of CPUs"),
+            Arg::with_name("lib")
+                .long("lib")
+                .conflicts_with_all(&["bin", "example", "test", "bench"])
+                .help("Build only this package's library"),
+            Arg::with_name("bin")
+                .long("bin")
+                .takes_value(true)
+                .value_name("NAME")
+                .conflicts_with_all(&["lib", "example", "test", "bench"])
+                .help("Build only the specified binary"),
+            Arg::with_name("example")
+                .long("example")
+                .takes_value(true)
+                .value_name("NAME")
+                .conflicts_with_all(&["lib", "bin", "test", "bench"])
+                .help("Build only the specified example"),
+            Arg::with_name("test")
+                .long("test")
+                .takes_value(true)
+                .value_name("NAME")
+                .conflicts_with_all(&["lib", "bin", "example", "bench"])
+                .help("Build only the specified test target"),
+            Arg::with_name("bench")
+                .long("bench")
+                .takes_value(true)
+                .value_name("NAME")
+                .conflicts_with_all(&["lib", "bin", "example", "test"])
+                .help("Build only the specified bench target"),
+            Arg::with_name("release")
+                .long("release")
+                .help("Build artifacts in release mode, with optimizations"),
+            Arg::with_name("profile")
+                .long("profile")
+                .value_name("PROFILE-NAME")
+                .help("Build artifacts with the specified profile"),
+            Arg::with_name("features")
+                .long("features")
+                .multiple(true)
+                .number_of_values(1)
+                .takes_value(true)
+                .value_name("FEATURES")
+                .help("Space-separated list of features to activate"),
+            Arg::with_name("all-features")
+                .long("all-features")
+                .help("Do not activate the `default` feature"),
+            Arg::with_name("no-default-features")
+                .long("no-default-features")
+                .help("Activate all available features"),
+            Arg::with_name("target")
+                .long("target")
+                .takes_value(true)
+                .value_name("TRIPLE")
+                .help("Target triple for which the code is compiled"),
+            Arg::with_name("color")
+                .long("color")
+                .takes_value(true)
+                .possible_values(&["auto", "always", "never"])
+                .help("Coloring: auto, always, never"),
+            Arg::with_name("frozen")
+                .long("frozen")
+                .help("Require Cargo.lock and cache are up to date"),
+            Arg::with_name("locked")
+                .long("locked")
+                .help("Require Cargo.lock is up to date"),
+            Arg::with_name("offline")
+                .long("offline")
+                .help("Run without accessing the network"),
+            Arg::with_name("unstable-features")
+                .short("Z")
+                .multiple(true)
+                .number_of_values(1)
+                .takes_value(true)
+                .value_name("FLAG")
+                .help("Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details"),
+        ])
+        .get_matches()
+    } else {
+        app.get_matches()
+    }
+}
+
+pub fn run(tool: Tool, matches: ArgMatches) -> Result<i32> {
     let mut metadata_command = MetadataCommand::new();
-    let mut cargo = Command::new("cargo");
-    cargo.arg("build");
-
-    if matches.is_present("quiet") {
-        cargo.arg("--quiet");
+    if let Some(features) = matches.values_of("features") {
+        metadata_command.features(CargoOpt::SomeFeatures(
+            features.map(|s| s.to_owned()).collect(),
+        ));
+    } else if matches.is_present("no-default-features") {
+        metadata_command.features(CargoOpt::NoDefaultFeatures);
+    } else if matches.is_present("all-features") {
+        metadata_command.features(CargoOpt::AllFeatures);
+    }
+    let metadata = metadata_command.exec()?;
+    if metadata.workspace_members.is_empty() {
+        bail!("Unable to find workspace members");
     }
 
-    if let Some(color) = matches.value_of("color") {
-        cargo.arg("--color");
-        cargo.arg(color);
+    let target_artifact = if tool.needs_build() {
+        cargo_build(&matches, &metadata)?
+    } else {
+        None
+    };
+
+    let mut tool_args = vec![];
+    if let Some(args) = matches.values_of("args") {
+        tool_args.extend(args);
+    }
+
+    let mut lltool = Command::new(format!("rust-{}", tool.name()));
+
+    if tool == Tool::Objdump {
+        let ctxt = if let Some(artifact) = &target_artifact {
+            Context::from_artifact(metadata, artifact)?
+        } else {
+            Context::from_flag(metadata, matches.value_of("target"))?
+        };
+
+        let arch_name = llvm::arch_name(&ctxt.cfg, &ctxt.target);
+
+        if arch_name == "thumb" {
+            // `-arch-name=thumb` doesn't produce the right output so instead we pass
+            // `-triple=$target`, which contains more information about the target
+            lltool.args(&["-triple", &ctxt.target]);
+        } else {
+            lltool.args(&["-arch-name", arch_name]);
+        }
+    }
+
+    // Extra flags
+    if let Tool::Readobj = tool {
+        // The default output style of `readobj` is JSON-like, which is not user friendly, so we
+        // change it to the human readable GNU style
+        lltool.arg("-elf-output-style=GNU");
+    }
+
+    if tool.needs_build() {
+        // Artifact
+        if let Some(artifact) = &target_artifact {
+            let file = match &artifact.executable {
+                // Example and bins have an executable
+                Some(val) => val,
+                // Libs have an rlib and an rmeta. We want the rlib, which always
+                // comes first in the filenames array after some quick testing.
+                //
+                // We could instead look for files ending in .rlib, but that would
+                // fail for cdylib and other fancy crate kinds.
+                None => &artifact.filenames[0],
+            };
+
+            match tool {
+                // Tools that don't need a build
+                Tool::Ar | Tool::Lld | Tool::Profdata => {}
+                // for some tools we change the CWD (current working directory) and
+                // make the artifact path relative. This makes the path that the
+                // tool will print easier to read. e.g. `libfoo.rlib` instead of
+                // `/home/user/rust/project/target/$T/debug/libfoo.rlib`.
+                Tool::Objdump | Tool::Nm | Tool::Readobj | Tool::Size => {
+                    lltool
+                        .current_dir(file.parent().unwrap())
+                        .arg(file.file_name().unwrap());
+                }
+                Tool::Objcopy | Tool::Strip => {
+                    lltool.arg(file);
+                }
+            }
+        }
+    }
+
+    // User flags
+    lltool.args(&tool_args);
+
+    if matches.is_present("verbose") {
+        eprintln!("{:?}", lltool);
+    }
+
+    let stdout = io::stdout();
+    let mut stdout = stdout.lock();
+
+    let output = lltool.stderr(Stdio::inherit()).output()?;
+
+    // post process output
+    let processed_output = match tool {
+        Tool::Ar | Tool::Lld | Tool::Objcopy | Tool::Profdata | Tool::Strip => output.stdout.into(),
+        Tool::Nm | Tool::Objdump | Tool::Readobj => postprocess::demangle(&output.stdout),
+        Tool::Size => postprocess::size(&output.stdout),
+    };
+
+    stdout.write_all(&*processed_output)?;
+
+    if output.status.success() {
+        Ok(0)
+    } else {
+        Ok(output.status.code().unwrap_or(1))
+    }
+}
+
+fn cargo_build(matches: &ArgMatches, metadata: &Metadata) -> Result<Option<Artifact>> {
+    let cargo = env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    let mut cargo = Command::new(cargo);
+    cargo.arg("build");
+
+    let (build_type, verbose) = cargo_build_args(matches, &mut cargo);
+
+    cargo.arg("--message-format=json");
+    cargo.stdout(Stdio::piped());
+
+    if verbose > 0 {
+        eprintln!("{:?}", cargo);
+    }
+
+    let mut child = cargo.spawn()?;
+    let stdout = BufReader::new(child.stdout.take().expect("Pipe to cargo process failed"));
+
+    // Note: We call `collect` to ensure we don't block stdout which could prevent the process from exiting
+    let messages = Message::parse_stream(stdout).collect::<Vec<_>>();
+
+    let status = child.wait()?;
+    if !status.success() {
+        bail!("Failed to parse crate metadata");
+    }
+
+    let mut target_artifact: Option<Artifact> = None;
+    for message in messages {
+        match message? {
+            Message::CompilerArtifact(artifact) => {
+                if metadata.workspace_members.contains(&artifact.package_id)
+                    && build_type.matches(&artifact)
+                {
+                    if target_artifact.is_some() {
+                        bail!("Can only have one matching artifact but found several");
+                    }
+
+                    target_artifact = Some(artifact);
+                }
+            }
+            Message::CompilerMessage(msg) => {
+                if let Some(rendered) = msg.message.rendered {
+                    print!("{}", rendered);
+                }
+            }
+            _ => (),
+        }
+    }
+
+    if target_artifact.is_none() {
+        bail!("Could not determine the wanted artifact");
+    }
+
+    Ok(target_artifact)
+}
+
+fn cargo_build_args<'a>(matches: &'a ArgMatches<'a>, cargo: &mut Command) -> (BuildType<'a>, u64) {
+    if matches.is_present("quiet") {
+        cargo.arg("--quiet");
     }
 
     if let Some(package) = matches.value_of("package") {
@@ -189,18 +454,9 @@ fn determine_artifact(matches: &clap::ArgMatches) -> Result<(Metadata, Option<Ar
         cargo.arg(package);
     }
 
-    // NOTE we do *not* use `project.target()` here because Cargo will figure things out on
-    // its own (i.e. it will search and parse .cargo/config, etc.)
-    if let Some(target) = target_flag {
-        cargo.args(&["--target", target]);
-    }
-
-    if matches.is_present("all-features") {
-        cargo.arg("--all-features");
-        metadata_command.features(CargoOpt::AllFeatures);
-    } else if let Some(features) = matches.value_of("features") {
-        cargo.args(&["--features", features]);
-        metadata_command.features(CargoOpt::SomeFeatures(vec![features.to_owned()]));
+    if let Some(jobs) = matches.value_of("jobs") {
+        cargo.arg("-j");
+        cargo.arg(jobs);
     }
 
     let build_type = if matches.is_present("lib") {
@@ -226,272 +482,54 @@ fn determine_artifact(matches: &clap::ArgMatches) -> Result<(Metadata, Option<Ar
         cargo.arg("--release");
     }
 
-    cargo.arg("--message-format=json");
-    cargo.stdout(Stdio::piped());
-
-    if verbose {
-        eprintln!("{:?}", cargo);
+    if let Some(profile) = matches.value_of("profile") {
+        cargo.arg("--profile");
+        cargo.arg(profile);
     }
 
-    let metadata = metadata_command.exec()?;
-    if metadata.workspace_members.len() == 0 {
-        bail!("Unable to find workspace members");
+    if let Some(features) = matches.values_of("features") {
+        for feature in features {
+            cargo.args(&["--features", feature]);
+        }
+    } else if matches.is_present("no-default-features") {
+        cargo.arg("--no-default-features");
+    } else if matches.is_present("all-features") {
+        cargo.arg("--all-features");
     }
 
-    let mut child = cargo.spawn()?;
-    let stdout = BufReader::new(child.stdout.take().expect("Pipe to cargo process failed"));
-
-    // Note: We call `collect` to ensure we don't block stdout which could prevent the process from exiting
-    let messages = Message::parse_stream(stdout).collect::<Vec<_>>();
-
-    let status = child.wait()?;
-    if !status.success() {
-        bail!("Failed to parse crate metadata");
+    // NOTE we do *not* use `project.target()` here because Cargo will figure things out on
+    // its own (i.e. it will search and parse .cargo/config, etc.)
+    if let Some(target) = matches.value_of("target") {
+        cargo.args(&["--target", target]);
     }
 
-    let mut wanted_artifact = None;
-    for message in messages {
-        match message? {
-            Message::CompilerArtifact(artifact) => {
-                if metadata.workspace_members.contains(&artifact.package_id)
-                    && build_type.matches(&artifact)
-                {
-                    if wanted_artifact.is_some() {
-                        bail!("Can only have one matching artifact but found several");
-                    }
+    let verbose = matches.occurrences_of("verbose");
+    if verbose > 1 {
+        cargo.arg(format!("-{}", "v".repeat((verbose - 1) as usize)));
+    }
 
-                    wanted_artifact = Some(artifact);
-                }
-            }
-            Message::CompilerMessage(msg) => {
-                if let Some(rendered) = msg.message.rendered {
-                    print!("{}", rendered);
-                }
-            }
-            _ => (),
+    if let Some(color) = matches.value_of("color") {
+        cargo.arg("--color");
+        cargo.arg(color);
+    }
+
+    if matches.is_present("frozen") {
+        cargo.arg("--frozen");
+    }
+
+    if matches.is_present("locked") {
+        cargo.arg("--locked");
+    }
+
+    if matches.is_present("offline") {
+        cargo.arg("--offline");
+    }
+
+    if let Some(unstable_features) = matches.values_of("Z") {
+        for unstable_feature in unstable_features {
+            cargo.args(&["-Z", unstable_feature]);
         }
     }
 
-    if wanted_artifact.is_none() {
-        bail!("Could not determine the wanted artifact");
-    }
-
-    Ok((metadata, wanted_artifact))
-}
-
-pub fn run(tool: Tool, examples: Option<&str>) -> Result<i32> {
-    let name = tool.name();
-    let about = format!(
-        "Proxy for the `llvm-{}` tool shipped with the Rust toolchain.",
-        name
-    );
-    let after_help = format!(
-        "\
-The arguments specified *after* the `--` will be passed to the proxied tool invocation.
-
-To see all the flags the proxied tool accepts run `cargo-{} -- -help`.{}",
-        name,
-        examples.unwrap_or("")
-    );
-    let app = App::new(format!("cargo-{}", name))
-        .about(&*about)
-        .version(env!("CARGO_PKG_VERSION"))
-        .settings(&[
-            AppSettings::UnifiedHelpMessage,
-            AppSettings::DeriveDisplayOrder,
-            AppSettings::DontCollapseArgsInUsage,
-        ])
-        // as this is used as a Cargo subcommand the first argument will be the name of the binary
-        // we ignore this argument
-        .arg(Arg::with_name("binary-name").hidden(true))
-        .arg(
-            Arg::with_name("quiet")
-                .long("quiet")
-                .short("q")
-                .help("Don't print build output from `cargo build`"),
-        )
-        .arg(
-            Arg::with_name("target")
-                .long("target")
-                .takes_value(true)
-                .value_name("TRIPLE")
-                .help("Target triple for which the code is compiled"),
-        )
-        .arg(
-            Arg::with_name("verbose")
-                .long("verbose")
-                .short("v")
-                .help("Use verbose output"),
-        )
-        .arg(
-            Arg::with_name("color")
-                .long("color")
-                .takes_value(true)
-                .possible_values(&["auto", "always", "never"])
-                .help("Coloring: auto, always, never"),
-        )
-        .arg(
-            Arg::with_name("args")
-                .last(true)
-                .multiple(true)
-                .help("The arguments to be proxied to the tool"),
-        )
-        .after_help(&*after_help);
-
-    let app = if tool.needs_build() {
-        app.arg(
-            Arg::with_name("package")
-                .long("package")
-                .short("p")
-                .takes_value(true)
-                .value_name("SPEC")
-                .help("Package to build (see `cargo help pkgid`)"),
-        )
-        .arg(
-            Arg::with_name("lib")
-                .long("lib")
-                .conflicts_with_all(&["bin", "example", "test", "bench"])
-                .help("Build only this package's library"),
-        )
-        .arg(
-            Arg::with_name("bin")
-                .long("bin")
-                .takes_value(true)
-                .value_name("NAME")
-                .conflicts_with_all(&["lib", "example", "test", "bench"])
-                .help("Build only the specified binary"),
-        )
-        .arg(
-            Arg::with_name("example")
-                .long("example")
-                .takes_value(true)
-                .value_name("NAME")
-                .conflicts_with_all(&["lib", "bin", "test", "bench"])
-                .help("Build only the specified example"),
-        )
-        .arg(
-            Arg::with_name("test")
-                .long("test")
-                .takes_value(true)
-                .value_name("NAME")
-                .conflicts_with_all(&["lib", "bin", "example", "bench"])
-                .help("Build only the specified test target"),
-        )
-        .arg(
-            Arg::with_name("bench")
-                .long("bench")
-                .takes_value(true)
-                .value_name("NAME")
-                .conflicts_with_all(&["lib", "bin", "example", "test"])
-                .help("Build only the specified bench target"),
-        )
-        .arg(
-            Arg::with_name("release")
-                .long("release")
-                .help("Build artifacts in release mode, with optimizations"),
-        )
-        .arg(
-            Arg::with_name("features")
-                .long("features")
-                .takes_value(true)
-                .value_name("FEATURES")
-                .help("Space-separated list of features to activate"),
-        )
-        .arg(
-            Arg::with_name("all-features")
-                .long("all-features")
-                .takes_value(false)
-                .help("Activate all available features"),
-        )
-    } else {
-        app
-    };
-
-    let matches = app.get_matches();
-    let verbose = matches.is_present("verbose");
-    let target_flag = matches.value_of("target");
-
-    // Figure out which artifact to use with the tool
-    let (metadata, artifact) = determine_artifact(&matches)?;
-
-    let mut tool_args = vec![];
-    if let Some(args) = matches.values_of("args") {
-        tool_args.extend(args);
-    }
-
-    let ctxt = if let Some(artifact) = &artifact {
-        Context::from_artifact(metadata, artifact)?
-    } else {
-        Context::from_flag(metadata, target_flag)?
-    };
-
-    let mut lltool = ctxt.tool(tool, &ctxt.target);
-
-    // Extra flags
-    match tool {
-        Tool::Readobj => {
-            // The default output style of `readobj` is JSON-like, which is not user friendly, so we
-            // change it to the human readable GNU style
-            lltool.arg("-elf-output-style=GNU");
-        }
-        _ => {}
-    }
-
-    // Artifact
-    if let Some(artifact) = &artifact {
-        let file = match &artifact.executable {
-            // Example and bins have an executable
-            Some(val) => val,
-            // Libs have an rlib and an rmeta. We want the rlib, which always
-            // comes first in the filenames array after some quick testing.
-            //
-            // We could instead look for files ending in .rlib, but that would
-            // fail for cdylib and other fancy crate kinds.
-            None => &artifact.filenames[0],
-        };
-
-        match tool {
-            // Tools that don't need a build
-            Tool::Ar | Tool::Lld | Tool::Profdata => {}
-            // for some tools we change the CWD (current working directory) and
-            // make the artifact path relative. This makes the path that the
-            // tool will print easier to read. e.g. `libfoo.rlib` instead of
-            // `/home/user/rust/project/target/$T/debug/libfoo.rlib`.
-            Tool::Objdump | Tool::Nm | Tool::Readobj | Tool::Size => {
-                lltool
-                    .current_dir(file.parent().unwrap())
-                    .arg(file.file_name().unwrap());
-            }
-            Tool::Objcopy | Tool::Strip => {
-                lltool.arg(file);
-            }
-        }
-    }
-
-    // User flags
-    lltool.args(&tool_args);
-
-    if verbose {
-        eprintln!("{:?}", lltool);
-    }
-
-    let stdout = io::stdout();
-    let mut stdout = stdout.lock();
-
-    let output = lltool.stderr(Stdio::inherit()).output()?;
-
-    // post process output
-    let pp_output = match tool {
-        Tool::Ar | Tool::Lld | Tool::Objcopy | Tool::Profdata | Tool::Strip => output.stdout.into(),
-        Tool::Nm | Tool::Objdump | Tool::Readobj => postprocess::demangle(&output.stdout),
-        Tool::Size => postprocess::size(&output.stdout),
-    };
-
-    stdout.write_all(&*pp_output)?;
-
-    if output.status.success() {
-        Ok(0)
-    } else {
-        Ok(output.status.code().unwrap_or(1))
-    }
+    (build_type, verbose)
 }

--- a/src/postprocess.rs
+++ b/src/postprocess.rs
@@ -2,7 +2,6 @@ use std::borrow::Cow;
 use std::str;
 
 use regex::{Captures, Regex};
-use rustc_demangle;
 
 // Here we post process the output of some tools to improve. If the output of the tool is not valid
 // UTF-8 then we don't touch it.

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -76,8 +76,24 @@ impl Tool {
         process::exit(status.code().unwrap_or(101));
     }
 
+    /// Parses arguments for `cargo $tool` and then if needed executes `cargo build`
+    /// before parsing the required arguments to `rust-$tool`.
+    /// If the tool fails to start or is not found this process exits with
+    /// status code 101 the same as if the process has a panic!
+    pub fn cargo_exec(self, examples: Option<&str>) -> ! {
+        let matches = crate::args(self, examples);
+
+        match crate::run(self, matches) {
+            Err(e) => {
+                eprintln!("error: {}", e);
+                process::exit(101)
+            }
+            Ok(ec) => process::exit(ec),
+        }
+    }
+
     // Whether this tool requires the project to be previously built
-    pub(crate) fn needs_build(self) -> bool {
+    pub fn needs_build(self) -> bool {
         match self {
             Tool::Ar | Tool::Lld | Tool::Profdata => false,
             Tool::Nm | Tool::Objcopy | Tool::Objdump | Tool::Readobj | Tool::Size | Tool::Strip => {


### PR DESCRIPTION
## Added
- Added `--no-default-features` cargo argument support
- Added `--profile` argument to allow specifying the profile to build the target package with
- Added `--frozen`, `--locked`, `--offline` cargo argument support
- Added `-Z` argument to allow use of unstable cargo features

## Fixed
- Fixed `cargo build` running for `cargo profdata` when its not required
- Fixed `--features` not allowing multiple

## Changes
- Allowed  multiple levels of verbosity and verbose cargo output via `-vv` and `-vvv`
- Changed `src/bin/cargo-*.rs` to use `Tool::cargo_exec` similar to `Tool::rust_exec` used in `src/bin/rust-*.rs`
- Removed unneeded `Endian` enum and  `Context::rustc_cfg`
- In-lined `Context::tool`
- Moved code so `Context` is only retrieved for `Tool::Objdump` as that's currently the only use case for it, this reduces calls to `rustc_version::version_meta()` for all other tools
- Re-split `determine_artifact` and `run` by in-lining and then extracting `args`, `cargo_build` and `cargo_build_args` functions
- Organized args to be the same order as in `cargo --help` to allow for easier comparison
- Used [`cargo clippy`](https://github.com/rust-lang/rust-clippy) to find and cleanup some minor issues

---

Few changes packed together in this one, let me know if you would prefer for it to be broken down.

Pending review of this PR, I agree it may be time for a release 😃 

r? @therealprof
