### PR TITLE
Support multiple cargo_metadata feature options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/rust-embedded/cargo-binutils/"
 version = "0.3.0"
 
 [dependencies]
-cargo_metadata = "0.10"
+cargo_metadata = "0.11"
 clap = "2.33"
 regex = "1.3"
 rustc-cfg = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,9 +280,11 @@ pub fn run(tool: Tool, matches: ArgMatches) -> Result<i32> {
         metadata_command.features(CargoOpt::SomeFeatures(
             features.map(|s| s.to_owned()).collect(),
         ));
-    } else if matches.is_present("no-default-features") {
+    }
+    if matches.is_present("no-default-features") {
         metadata_command.features(CargoOpt::NoDefaultFeatures);
-    } else if matches.is_present("all-features") {
+    }
+    if matches.is_present("all-features") {
         metadata_command.features(CargoOpt::AllFeatures);
     }
     let metadata = metadata_command.exec()?;


### PR DESCRIPTION
The PR follows #78, which did not correct `cargo_metadata` feature exclusivity. oli-obk/cargo_metadata#118 lets us combine feature options, like `--no-default-features --features foo`, so we can fix our usage here. As of this PR, the return of `cargo_metadata` will truly reflect whatever feature options the user passes to `cargo-binutils`.

The `cargo_metadata` change was published in `0.10.1`, but this PR bumps to `0.11`, which is backwards compatible with `0.10`.