### PR TITLE
Add rust-cov / cargo-cov for llvm-cov

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,7 +159,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/rust-embedded/cargo-binutils/compare/v0.3.2...HEAD
+[Unreleased]: https://github.com/rust-embedded/cargo-binutils/compare/v0.3.3...HEAD
 [v0.3.3]: https://github.com/rust-embedded/cargo-binutils/compare/v0.3.2...v0.3.3
 [v0.3.2]: https://github.com/rust-embedded/cargo-binutils/compare/v0.3.1...v0.3.2
 [v0.3.1]: https://github.com/rust-embedded/cargo-binutils/compare/v0.3.0...v0.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.3.3] - 2020-11-17
+
+### Added
+
+- rust-cov / `cargo cov` - proxy for `llvm-cov` used in combination with
+  `profdata` for Rust LLVM InstrProf-based source code coverage analysis.
+
 ## [v0.3.2] - 2020-10-13
 
 ### Fixed
@@ -153,6 +160,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Initial release
 
 [Unreleased]: https://github.com/rust-embedded/cargo-binutils/compare/v0.3.2...HEAD
+[v0.3.3]: https://github.com/rust-embedded/cargo-binutils/compare/v0.3.2...v0.3.3
 [v0.3.2]: https://github.com/rust-embedded/cargo-binutils/compare/v0.3.1...v0.3.2
 [v0.3.1]: https://github.com/rust-embedded/cargo-binutils/compare/v0.3.0...v0.3.1
 [v0.3.0]: https://github.com/rust-embedded/cargo-binutils/compare/v0.2.0...v0.3.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 name = "cargo-binutils"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/cargo-binutils/"
-version = "0.3.2"
+version = "0.3.3"
 
 [dependencies]
 cargo_metadata = "0.11"

--- a/src/bin/cargo-cov.rs
+++ b/src/bin/cargo-cov.rs
@@ -1,0 +1,3 @@
+fn main() {
+    cargo_binutils::Tool::Cov.cargo_exec(None)
+}

--- a/src/bin/rust-cov.rs
+++ b/src/bin/rust-cov.rs
@@ -1,0 +1,3 @@
+fn main() {
+    cargo_binutils::Tool::Cov.rust_exec()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,7 +352,7 @@ pub fn run(tool: Tool, matches: ArgMatches) -> Result<i32> {
 
             match tool {
                 // Tools that don't need a build
-                Tool::Ar | Tool::Lld | Tool::Profdata => {}
+                Tool::Ar | Tool::Cov | Tool::Lld | Tool::Profdata => {}
                 // for some tools we change the CWD (current working directory) and
                 // make the artifact path relative. This makes the path that the
                 // tool will print easier to read. e.g. `libfoo.rlib` instead of
@@ -383,7 +383,9 @@ pub fn run(tool: Tool, matches: ArgMatches) -> Result<i32> {
 
     // post process output
     let processed_output = match tool {
-        Tool::Ar | Tool::Lld | Tool::Objcopy | Tool::Profdata | Tool::Strip => output.stdout.into(),
+        Tool::Ar | Tool::Cov | Tool::Lld | Tool::Objcopy | Tool::Profdata | Tool::Strip => {
+            output.stdout.into()
+        }
         Tool::Nm | Tool::Objdump | Tool::Readobj => postprocess::demangle(&output.stdout),
         Tool::Size => postprocess::size(&output.stdout),
     };

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -10,6 +10,7 @@ use crate::rustc::rustlib;
 #[derive(Clone, Copy, PartialEq)]
 pub enum Tool {
     Ar,
+    Cov,
     Lld,
     Nm,
     Objcopy,
@@ -24,6 +25,7 @@ impl Tool {
     pub fn name(self) -> &'static str {
         match self {
             Tool::Ar => "ar",
+            Tool::Cov => "cov",
             Tool::Lld => "lld",
             Tool::Nm => "nm",
             Tool::Objcopy => "objcopy",
@@ -95,7 +97,7 @@ impl Tool {
     // Whether this tool requires the project to be previously built
     pub fn needs_build(self) -> bool {
         match self {
-            Tool::Ar | Tool::Lld | Tool::Profdata => false,
+            Tool::Ar | Tool::Cov | Tool::Lld | Tool::Profdata => false,
             Tool::Nm | Tool::Objcopy | Tool::Objdump | Tool::Readobj | Tool::Size | Tool::Strip => {
                 true
             }


### PR DESCRIPTION
Rust now includes `llvm-cov`, which is used in combination with
`llvm-profdata` to generate coverage reports from the `.profraw` files
now generated by Rust binaries compiled with `-Z instrument-coverage`.