### PR TITLE
README.md: Fix objdump example

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ $ stat --printf="%s\n" app.bin
 Disassemble a binary.
 
 ``` console
-$ cargo objdump --release -- -disassemble -no-show-raw-insn
+$ cargo objdump --release -- --disassemble --no-show-raw-insn
 target/thumbv7m-none-eabi/debug/app:    file format ELF32-arm-little
 
 Disassembly of section .text:


### PR DESCRIPTION
objdump needs a double dash for long flags.