### PR TITLE
Bump MSRV to 1.42.0

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -2,9 +2,9 @@ block_labels = ["needs-decision"]
 delete_merged_branches = true
 required_approvals = 1
 status = [
-        "ci (1.38.0, ubuntu-latest, false)",
-        "ci (1.38.0, macos-latest, false)",
-        "ci (1.38.0, windows-latest, false)",
+        "ci (1.42.0, ubuntu-latest, false)",
+        "ci (1.42.0, macos-latest, false)",
+        "ci (1.42.0, windows-latest, false)",
         "ci (stable, ubuntu-latest, false)",
         "ci (stable, macos-latest, false)",
         "ci (stable, windows-latest, false)",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         rust: 
           # MSRV
-          - 1.38.0
+          - 1.42.0
           - stable
         os: [ubuntu-latest, macos-latest, windows-latest]
         experimental: [false]

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ linker = "rust-lld"
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.38.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.42.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License


### PR DESCRIPTION
memchr-2.4.0 used non_exhaustive, which is only available from 1.40.