### PR TITLE
Bump MSRV to 1.46

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -2,9 +2,9 @@ block_labels = ["needs-decision"]
 delete_merged_branches = true
 required_approvals = 1
 status = [
-        "ci (1.42.0, ubuntu-latest, false)",
-        "ci (1.42.0, macos-latest, false)",
-        "ci (1.42.0, windows-latest, false)",
+        "ci (1.46.0, ubuntu-latest, false)",
+        "ci (1.46.0, macos-latest, false)",
+        "ci (1.46.0, windows-latest, false)",
         "ci (stable, ubuntu-latest, false)",
         "ci (stable, macos-latest, false)",
         "ci (stable, windows-latest, false)",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         rust: 
           # MSRV
-          - 1.42.0
+          - 1.46.0
           - stable
         os: [ubuntu-latest, macos-latest, windows-latest]
         experimental: [false]

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ linker = "rust-lld"
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.42.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.46.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,7 +325,7 @@ pub fn run(tool: Tool, matches: ArgMatches) -> Result<i32> {
             // `-triple=$target`, which contains more information about the target
             lltool.args(&["--triple", &ctxt.target]);
         } else {
-            lltool.args(&["--arch-name", arch_name]);
+            lltool.args(&[format!("--arch-name={}", arch_name)]);
         }
     }
 


### PR DESCRIPTION
Required because our clap dependency uses a `bitfields!` macro which uses a `if` in a `const fn`, which was introduced in 1.46.

Should allow #108 to merge too.