### PR TITLE
Fix more typos in Readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Strip all symbols from the build artifact
 $ stat --printf="%s\n" target/release/hello
 4094240
 
-$ cargo-strip --release -- -strip-all -O smaller-hello
+$ cargo-strip --release -- --strip-all -o smaller-hello
 
 $ stat --printf="%s\n" smaller-hello
 424432


### PR DESCRIPTION
Anther missing dash and a wrong case for a option

I found these after i had submitted #114 or i would have just added them to that one, Thanks for merging so fast @Emilgardis :D

These are supper handy tools and have already helped me a load!