### PR TITLE
Update `regex` 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ version = "0.3.5"
 [dependencies]
 cargo_metadata = "0.11"
 clap = "2.33"
-regex = "1.3"
+regex = "1.5.5"
 rustc-cfg = "0.4"
 rustc-demangle = "0.1"
 rustc_version = "0.2"


### PR DESCRIPTION
Update `regex` to `1.5.5` as per [security advisory](https://blog.rust-lang.org/2022/03/08/cve-2022-24713.html)