### PR TITLE
ci: add action to build and release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+name: release
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - v*.*.*
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest,  suffix: .tar.gz }
+          - { target: x86_64-apple-darwin,      os: macos-latest,   suffix: .tar.gz }
+          - { target: aarch64-apple-darwin,     os: macos-latest,   suffix: .tar.gz }
+          - { target: x86_64-pc-windows-msvc,   os: windows-latest, suffix: .zip    }
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          target: ${{ matrix.target }}
+          override: true
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@v1
+        with:
+          key: ${{ matrix.target }}
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --target ${{ matrix.target }} --release
+
+      - name: (Not Windows) Move executables and compress
+        if: ${{ matrix.os != 'windows-latest' }}
+        run: |
+          mkdir ${{ matrix.target }}
+          for bin in src/bin/*.rs; do
+            mv target/${{ matrix.target }}/release/$(basename $bin .rs) ${{ matrix.target }};
+          done
+          tar -zcvf ${{ matrix.target }}.tar.gz ${{ matrix.target }}
+
+      - name: (Windows) Move executables and compress
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: |
+          mkdir ${{ matrix.target }}
+          $bins = Get-ChildItem -Path src/bin -Recurse -Filter "*.rs"
+          foreach ($b in $bins) {
+            Move-Item -Path ("target/${{ matrix.target }}/release/" + $b.BaseName + ".exe") -Destination "${{ matrix.target }}/"
+          }
+          Compress-Archive -Path ${{ matrix.target }} -DestinationPath ${{ matrix.target }}.zip
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.target }}
+          path: ${{ matrix.target }}${{ matrix.suffix }}
+
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+      - run: ls -R ./artifacts
+
+      - name: Set current date as environment variable
+        run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+
+      - id: changelog-reader
+        uses: mindsers/changelog-reader-action@v2.0.0
+        with:
+          version: ${{ (github.ref_type == 'tag' && github.ref_name) || 'Unreleased' }}
+
+      - uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.changelog-reader.outputs.version }}
+          name: ${{ (github.ref_type == 'tag' && steps.changelog-reader.outputs.version) || format('Prereleased {0}', env.CURRENT_DATE) }}
+          body: ${{ steps.changelog-reader.outputs.changes }}
+          prerelease: ${{ steps.changelog-reader.outputs.status == 'unreleased' }}
+          files: |
+            artifacts/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Action to build binaries and release for every version tag and latest commit
+
 ## [v0.3.5] - 2022-02-12
 
 ### Added


### PR DESCRIPTION
Add action similar to [the one used in svd2rust](https://github.com/rust-embedded/svd2rust/pull/608). In brief, the action does these work:

1. triggered when a new tag or commit is pushed
2. build and compress binaries
3. create a release and attach binaries

Currently, only 4 target platforms are supported: amd64 (Linux, Windows, macOS) and arm64 (macOS)