### PR TITLE
Add rust-as exposing llvm-as

### DIFF
--- a/src/bin/rust-as.rs
+++ b/src/bin/rust-as.rs
@@ -1,0 +1,3 @@
+fn main() {
+    cargo_binutils::Tool::As.rust_exec()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -355,7 +355,7 @@ pub fn run(tool: Tool, matches: ArgMatches) -> Result<i32> {
 
             match tool {
                 // Tools that don't need a build
-                Tool::Ar | Tool::Cov | Tool::Lld | Tool::Profdata => {}
+                Tool::Ar | Tool::As | Tool::Cov | Tool::Lld | Tool::Profdata => {}
                 // for some tools we change the CWD (current working directory) and
                 // make the artifact path relative. This makes the path that the
                 // tool will print easier to read. e.g. `libfoo.rlib` instead of
@@ -386,9 +386,13 @@ pub fn run(tool: Tool, matches: ArgMatches) -> Result<i32> {
 
     // post process output
     let processed_output = match tool {
-        Tool::Ar | Tool::Cov | Tool::Lld | Tool::Objcopy | Tool::Profdata | Tool::Strip => {
-            output.stdout.into()
-        }
+        Tool::Ar
+        | Tool::As
+        | Tool::Cov
+        | Tool::Lld
+        | Tool::Objcopy
+        | Tool::Profdata
+        | Tool::Strip => output.stdout.into(),
         Tool::Nm | Tool::Objdump | Tool::Readobj => postprocess::demangle(&output.stdout),
         Tool::Size => postprocess::size(&output.stdout),
     };

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -10,6 +10,7 @@ use crate::rustc::rustlib;
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum Tool {
     Ar,
+    As,
     Cov,
     Lld,
     Nm,
@@ -25,6 +26,7 @@ impl Tool {
     pub fn name(self) -> &'static str {
         match self {
             Tool::Ar => "ar",
+            Tool::As => "as",
             Tool::Cov => "cov",
             Tool::Lld => "lld",
             Tool::Nm => "nm",
@@ -102,7 +104,7 @@ impl Tool {
     // Whether this tool requires the project to be previously built
     pub fn needs_build(self) -> bool {
         match self {
-            Tool::Ar | Tool::Cov | Tool::Lld | Tool::Profdata => false,
+            Tool::Ar | Tool::As | Tool::Cov | Tool::Lld | Tool::Profdata => false,
             Tool::Nm | Tool::Objcopy | Tool::Objdump | Tool::Readobj | Tool::Size | Tool::Strip => {
                 true
             }


### PR DESCRIPTION
Closes https://github.com/rust-embedded/cargo-binutils/issues/33.

`llvm-as` has been available for a while: https://github.com/rust-lang/rust/pull/78968