### PR TITLE
Component is now named 'llvm-tools'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           rustup toolchain install ${{ matrix.rust }} --profile minimal
           rustup default ${{ matrix.rust }}
-          rustup component add llvm-tools-preview clippy rustfmt
+          rustup component add llvm-tools clippy rustfmt
           echo "::add-matcher::.github/workflows/rust.json"
 
       - name: Clippy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- The `llvm-tools-preview` component was renamed to `llvm-tools`
+
 ### Changed
 
 - MSRV Changed to 1.70.0

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This project is developed and maintained by the [Embedded WG Tools team][team].
 ``` console
 $ cargo install cargo-binutils
 
-$ rustup component add llvm-tools-preview
+$ rustup component add llvm-tools
 ```
 
 ## Usage
@@ -35,7 +35,7 @@ $ $(find $(rustc --print sysroot) -name llvm-$tool) ${args[@]}
 ```
 
 Apart from these `rust-*` tools, which are direct proxies for the llvm tools in
-the `llvm-tools-preview` component, the crate also provides some Cargo
+the `llvm-tools` component, the crate also provides some Cargo
 subcommands that will first build the project and then run the llvm tool on the
 output artifact. This:
 
@@ -71,7 +71,7 @@ artifact be automatically passed to the LLVM tool. This mode only works when the
 subcommand is used from within a Cargo project.
 
 *Disclaimer* Note that `cargo-binutils` simply proxies the LLVM tools in the
-`llvm-tools-preview` component and the Rust project makes no guarantee about the
+`llvm-tools` component and the Rust project makes no guarantee about the
 availability and the CLI of these tools -- i.e. the availability and CLI of
 these tools may change as new Rust releases are made.
 

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -65,7 +65,11 @@ impl Tool {
         };
 
         if !path.exists() {
-            eprintln!("Could not find tool: {}\nat: {}\nConsider `rustup component add llvm-tools-preview`", self.name(), path.to_string_lossy());
+            eprintln!(
+                "Could not find tool: {}\nat: {}\nConsider `rustup component add llvm-tools`",
+                self.name(),
+                path.to_string_lossy()
+            );
             process::exit(102)
         };
 


### PR DESCRIPTION
I don't know exactly when the name changed from `llvm-tools-preview` to `llvm-tools` but this works for 1.70 (MSRV for this crate) and later.