### PR TITLE
`cargo build` diagnostic improvements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -414,7 +414,7 @@ fn cargo_build(matches: &ArgMatches, metadata: &Metadata) -> Result<Option<Artif
     let (build_type, verbose) = cargo_build_args(matches, &mut cargo);
     let quiet = matches.get_flag("quiet");
 
-    cargo.arg("--message-format=json");
+    cargo.arg("--message-format=json-diagnostic-rendered-ansi");
     cargo.stdout(Stdio::piped());
 
     if verbose > 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -428,9 +428,6 @@ fn cargo_build(matches: &ArgMatches, metadata: &Metadata) -> Result<Option<Artif
     let messages = Message::parse_stream(stdout).collect::<Vec<_>>();
 
     let status = child.wait()?;
-    if !status.success() {
-        bail!("Failed to parse crate metadata");
-    }
 
     let mut target_artifact: Option<Artifact> = None;
     for message in messages {
@@ -455,6 +452,10 @@ fn cargo_build(matches: &ArgMatches, metadata: &Metadata) -> Result<Option<Artif
             }
             _ => (),
         }
+    }
+
+    if !status.success() {
+        bail!("Failed to parse crate metadata");
     }
 
     if target_artifact.is_none() {


### PR DESCRIPTION
I use `cargo objcopy` to compile some projects, but the unformatted messages are challenging to scan visually. The diagnostics are also not printed if there is a build error.

For those two reasons, I often find myself falling back to `cargo build` instead. But that means sometimes I will _only_ run `cargo build`, thus not creating a new version of the flashable binary, and losing track of whether or not my changes are doing anything.

Typing this out now, I realize that something like `cargo build && cargo objcopy` would probably solve most of my problems, but I think changing those two defaults would still be a big usability improvement over the current behavior of the binutils tools.