### PR TITLE
Fix `clippy::needless_as_bytes` lint failure

### DIFF
--- a/src/postprocess.rs
+++ b/src/postprocess.rs
@@ -38,7 +38,7 @@ pub fn size(bytes: &[u8]) -> Cow<[u8]> {
                     Some((needle, addr)) if line.starts_with('.') => {
                         let pos = line.rfind(needle).unwrap();
                         let hex_addr = format!("{addr:#x}");
-                        let start = pos + needle.as_bytes().len() - hex_addr.as_bytes().len();
+                        let start = pos + needle.len() - hex_addr.len();
 
                         format!("{}{}", &line[..start], hex_addr).into()
                     }


### PR DESCRIPTION
The `clippy::needless_as_bytes` lint was added in Rust 1.84.0, causing recent CI runs to fail.