### PR TITLE
Pass tool manifest path on to cargo metadata command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed metadata error when using `--manifest-path` outside of a project folder. 
+
+### Changed
+
 - The `llvm-tools-preview` component was renamed to `llvm-tools`
 
 ### Changed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,6 +291,9 @@ pub fn run(tool: Tool, matches: ArgMatches) -> Result<i32> {
     if matches.get_flag("all-features") {
         metadata_command.features(CargoOpt::AllFeatures);
     }
+    if let Some(path) = matches.get_one::<String>("manifest-path") {
+        metadata_command.manifest_path(path);
+    }
     let metadata = metadata_command.exec()?;
     if metadata.workspace_members.is_empty() {
         bail!("Unable to find workspace members");


### PR DESCRIPTION
This seems to fix an issue with running `cargo objcopy` (and likely other binutils) outside of a project directory.  For example, when I run `cargo objcopy` outside of a project directory, I get the following error:
```
cargo metadata` exited with an error: error: could not find `Cargo.toml` in `<some path>` or any parent directory`
```
Passing the `manifest-path` along to the `MetadataCommand` fixes this, and seems to align the behavior of binutils with `cargo build`.  
