### PR TITLE
Redirect cargo build output to stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Redirected cargo build output to stderr instead of stdout. This prevents cargo/rustc messages and warnings from appearing in the stdout of cargo-binutils tools, making it easier to pipe or redirect tool output cleanly.
+
 ## [v0.4.0] - 2025-08-26
 
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -449,7 +449,7 @@ fn cargo_build(matches: &ArgMatches, metadata: &Metadata) -> Result<Option<Artif
             Message::CompilerMessage(msg) => {
                 if !quiet || verbose > 1 {
                     if let Some(rendered) = msg.message.rendered {
-                        print!("{rendered}");
+                        eprint!("{rendered}");
                     }
                 }
             }


### PR DESCRIPTION
This PR changes the cargo build invocation so that all cargo/rustc messages and warnings are sent to stderr, not stdout. This solves the problem where output from cargo nm, cargo objdump, etc. would include cargo/rustc messages when piping or redirecting stdout, as described in #111.

Why?

- When redirecting or piping stdout, users expect only the tool's output, not build messages or warnings.
- Now, `cargo objdump -- -s > dump` and similar commands will only save the tool output to file.
- Users can easily silence build output with `2>/dev/null` if desired.

Fixes: #111