### PR TITLE
Pass `--no-deps` to cargo metadata

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,6 +281,7 @@ To see all the flags the proxied tool accepts run `cargo-{} -- --help`.{}",
 
 pub fn run(tool: Tool, matches: ArgMatches) -> Result<i32> {
     let mut metadata_command = MetadataCommand::new();
+    metadata_command.no_deps();
     if tool.needs_build() {
         if let Some(features) = matches.get_many::<String>("features") {
             metadata_command.features(CargoOpt::SomeFeatures(


### PR DESCRIPTION
We never use anything other than the workspace members and the `target` field. Don't collect unnecessary info.

As a side effect, this causes cargo-binutils to work even with very old versions of Cargo that use `resolver = "1"` by default.