### PR TITLE
Don't run `cargo metadata` for tools that don't need it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,6 +281,7 @@ To see all the flags the proxied tool accepts run `cargo-{} -- --help`.{}",
 
 pub fn run(tool: Tool, matches: ArgMatches) -> Result<i32> {
     let mut metadata_command = MetadataCommand::new();
+    metadata_command.no_deps();
     if tool.needs_build() {
         if let Some(features) = matches.get_many::<String>("features") {
             metadata_command.features(CargoOpt::SomeFeatures(


### PR DESCRIPTION
We need metadata in the following cases:
- If we are building a tool from source
- If this is cargo-objdump and we are parsing the target in order to
  forward it to llvm-objdump

In all other cases, we don't need metadata and we can simply avoid
collecting it. Do so.

---

For convenience and to avoid rebase conflicts, this is written on top of https://github.com/rust-embedded/cargo-binutils/pull/166. Happy to separate it out if desired.