### PR TITLE
Add support for cargo-readelf command

### DIFF
--- a/src/bin/cargo-readelf.rs
+++ b/src/bin/cargo-readelf.rs
@@ -1,0 +1,10 @@
+const EXAMPLES: &str = "
+
+EXAMPLES
+
+`cargo readelf --bin app -- -t` - Display the section details
+`cargo readelf --bin app -- -s` - Display the symbol table";
+
+fn main() {
+    cargo_binutils::Tool::Readelf.cargo_exec(Some(EXAMPLES))
+}

--- a/src/bin/rust-readelf.rs
+++ b/src/bin/rust-readelf.rs
@@ -1,0 +1,3 @@
+fn main() {
+    cargo_binutils::Tool::Readelf.rust_exec()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,7 +373,7 @@ pub fn run(tool: Tool, matches: &ArgMatches) -> Result<i32> {
                 // make the artifact path relative. This makes the path that the
                 // tool will print easier to read. eg. `libfoo.rlib` instead of
                 // `/home/user/rust/project/target/$T/debug/libfoo.rlib`.
-                Tool::Objdump | Tool::Nm | Tool::Readobj | Tool::Size => {
+                Tool::Objdump | Tool::Nm | Tool::Readobj | Tool::Readelf | Tool::Size => {
                     lltool
                         .current_dir(file.parent().unwrap())
                         .arg(file.file_name().unwrap());
@@ -409,7 +409,9 @@ pub fn run(tool: Tool, matches: &ArgMatches) -> Result<i32> {
         | Tool::Objcopy
         | Tool::Profdata
         | Tool::Strip => output.stdout.into(),
-        Tool::Nm | Tool::Objdump | Tool::Readobj => postprocess::demangle(&output.stdout),
+        Tool::Nm | Tool::Objdump | Tool::Readobj | Tool::Readelf => {
+            postprocess::demangle(&output.stdout)
+        }
         Tool::Size => postprocess::size(&output.stdout),
     };
 
@@ -448,22 +450,19 @@ fn cargo_build(matches: &ArgMatches, metadata: &Metadata) -> Result<Option<Artif
     let mut target_artifact: Option<Artifact> = None;
     for message in messages {
         match message? {
-            Message::CompilerArtifact(artifact) => {
+            Message::CompilerArtifact(artifact)
                 if metadata.workspace_members.contains(&artifact.package_id)
-                    && build_type.matches(&artifact)
-                {
-                    if target_artifact.is_some() {
-                        bail!("Can only have one matching artifact but found several");
-                    }
-
-                    target_artifact = Some(artifact);
+                    && build_type.matches(&artifact) =>
+            {
+                if target_artifact.is_some() {
+                    bail!("Can only have one matching artifact but found several");
                 }
+
+                target_artifact = Some(artifact);
             }
-            Message::CompilerMessage(msg) => {
-                if !quiet || verbose > 1 {
-                    if let Some(rendered) = msg.message.rendered {
-                        eprint!("{rendered}");
-                    }
+            Message::CompilerMessage(msg) if (!quiet || verbose > 1) => {
+                if let Some(rendered) = msg.message.rendered {
+                    eprint!("{rendered}");
                 }
             }
             _ => (),

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -18,6 +18,7 @@ pub enum Tool {
     Objdump,
     Profdata,
     Readobj,
+    Readelf,
     Size,
     Strip,
 }
@@ -35,6 +36,7 @@ impl Tool {
             Self::Objdump => "objdump",
             Self::Profdata => "profdata",
             Self::Readobj => "readobj",
+            Self::Readelf => "readelf",
             Self::Size => "size",
             Self::Strip => "strip",
         }
@@ -112,9 +114,13 @@ impl Tool {
     pub const fn needs_build(self) -> bool {
         match self {
             Self::Ar | Self::As | Self::Cov | Self::Lld | Self::Profdata => false,
-            Self::Nm | Self::Objcopy | Self::Objdump | Self::Readobj | Self::Size | Self::Strip => {
-                true
-            }
+            Self::Nm
+            | Self::Objcopy
+            | Self::Objdump
+            | Self::Readobj
+            | Self::Readelf
+            | Self::Size
+            | Self::Strip => true,
         }
     }
 }


### PR DESCRIPTION
Allows developers to use the `cargo readelf` sub-command.

Fixes: #89